### PR TITLE
np.matrix deprecation:

### DIFF
--- a/src/astrohack/_utils/_algorithms.py
+++ b/src/astrohack/_utils/_algorithms.py
@@ -178,7 +178,7 @@ def _least_squares_fit(system, vector):
     
     result = fit[0]
     residuals = fit[1]
-    covar = np.matrix(np.dot(system.T, system)).I
+    covar = np.linalg.inv(np.dot(system.T, system))
     variances = np.diagonal(covar)
     
     return result, variances, residuals


### PR DESCRIPTION
Removed usage of the np.matrix class that is pending deprecation, fixes warnings raised during automated tests