### PR TITLE
Fixed bug where overwrite just appends new values to existing hack fi…

### DIFF
--- a/src/astrohack/_utils/_io.py
+++ b/src/astrohack/_utils/_io.py
@@ -33,8 +33,12 @@ def check_if_file_will_be_overwritten(file, overwrite):
         raise FileExistsError
         
     elif  (os.path.exists(file) is True) and (overwrite is True):
-        logger.warning(file + " will be overwritten.")
-        shutil.rmtree(file)
+        if file.endswith(".zarr"):
+            logger.warning(file + " will be overwritten.")
+            shutil.rmtree(file)
+        else:
+            logger.warning(file + ": is not a valid hack file. Check the file name again.")
+            raise Exception("IncorrectFileType: {file}".format(file=file))
 
 
 def _load_panel_file(file=None, panel_dict=None, dask_load=True):

--- a/src/astrohack/_utils/_io.py
+++ b/src/astrohack/_utils/_io.py
@@ -2,9 +2,10 @@ import os
 import json
 import zarr
 import copy
+import datetime
+import shutil
 import numpy as np
 import xarray as xr
-import datetime
 
 from astropy.io import fits
 from astrohack import __version__ as code_version
@@ -24,19 +25,16 @@ def check_if_file_exists(file):
         raise FileNotFoundError
 
 
-def check_if_file_will_be_overwritten(file,overwrite):
+def check_if_file_will_be_overwritten(file, overwrite):
     logger = _get_astrohack_logger()
     if (os.path.exists(file) is True) and (overwrite is False):
-        logger.error(
-            " {file} already exists. To overwite set the overwrite=True option in extract_holog or remove current file.".format(
-                file=file
-            )
-        )
+        logger.error(" {file} already exists. To overwite set the overwrite=True option in extract_holog or remove current file.".format(file=file))
+        
         raise FileExistsError
+        
     elif  (os.path.exists(file) is True) and (overwrite is True):
-        logger.warning(
-            file + " will be overwritten."
-        )
+        logger.warning(file + " will be overwritten.")
+        shutil.rmtree(file)
 
 
 def _load_panel_file(file=None, panel_dict=None, dask_load=True):

--- a/src/astrohack/extract_holog.py
+++ b/src/astrohack/extract_holog.py
@@ -231,7 +231,7 @@ def extract_holog(
     ddi_sel = extract_holog_parms['ddi_sel']
     if holog_obs_dict is None: #Automatically create holog_obs_dict
         from astrohack._utils._extract_holog import _create_holog_obs_dict
-        holog_obs_dict = _create_holog_obs_dict(pnt_dict, extract_holog_parms['baseline_average_distance'], extract_holog_parms['baseline_average_nearest'], ant_names,ant_pos,ant_names_main)
+        holog_obs_dict = _create_holog_obs_dict(pnt_dict, extract_holog_parms['baseline_average_distance'], extract_holog_parms['baseline_average_nearest'], ant_names, ant_pos, ant_names_main)
         
         #From the generated holog_obs_dict subselect user supplied ddis.
         if ddi_sel != 'all':
@@ -413,14 +413,18 @@ def extract_holog(
     holog_dict = _load_holog_file(holog_file=extract_holog_parms["holog_name"], dask_load=True, load_pnt_dict=False)
 
     extract_holog_parms['telescope_name'] = telescope_name
-    _create_holog_meta_data(holog_file=extract_holog_parms['holog_name'], holog_dict=holog_dict,
-                            input_params=input_params)
+
+    _create_holog_meta_data(
+        holog_file=extract_holog_parms['holog_name'], 
+        holog_dict=holog_dict,
+        input_params=input_params
+    )
     
     holog_mds = AstrohackHologFile(extract_holog_parms['holog_name'])
-    holog_mds.open()
-    
-    return holog_mds
 
+    holog_mds.open()
+
+    return holog_mds
 
 
 def _check_extract_holog_parms(

--- a/src/astrohack/holog.py
+++ b/src/astrohack/holog.py
@@ -132,7 +132,7 @@ def holog(
     input_params = holog_params.copy()
     
     check_if_file_exists(holog_params['holog_file'])
-    check_if_file_will_be_overwritten(holog_params['image_file'],holog_params['overwrite'])
+    check_if_file_will_be_overwritten(holog_params['image_file'], holog_params['overwrite'])
 
     json_data = "/".join((holog_params['holog_file'], ".holog_json"))
     with open(json_data, "r") as json_file:


### PR DESCRIPTION
The issue stemmed from the fact that when `overwrite=True` the code would just check and see the file existed and write a log message, then it would append to the zarr file anyway. This is probably because zarr files are just directories so the write wasn't actually "overwriting" anything. Now, when `overwrite=True` the hack file is deleted before re-writing.