### PR TITLE
87 provide function to compute and return holog observation dictionary

### DIFF
--- a/src/astrohack/_utils/_dio.py
+++ b/src/astrohack/_utils/_dio.py
@@ -614,3 +614,49 @@ def _print_json(object, indent=6, columns=7):
       print("{key}".format(key=key_str).rjust(indent, ' '))
       _print_json(value, indent+4, columns=columns)
       print("{close}".format(close="}").rjust(indent-4, ' '))
+
+def _reshape(array, columns):
+  size = len(array)
+  rows = int(size/columns)
+  if rows <= 0:
+    return 1, 0
+  else:  
+    remainder = size - (rows*columns)
+
+    return rows, remainder
+
+def _print_array(array, columns, indent=4):
+
+  rows, remainder = _reshape(array, columns)
+  
+  if columns > len(array):
+    columns = len(array)
+
+  str_line = ""
+
+  for i in range(rows):
+    temp = []
+    for j in range(columns):
+      k = columns*i + j
+      if j == 0:
+        temp.append("{:>3}".format(array[k]).rjust(indent, ' '))
+      else:
+        temp.append("{:>3}".format(array[k]))
+  
+    str_line += ", ".join(temp)
+    str_line += "\n"
+
+  temp = []
+  if remainder > 0:
+    for i in range(remainder):
+      index = columns*rows + i
+
+      if i == 0:
+        temp.append("{:>3}".format(array[index]).rjust(indent, ' '))
+      else:
+        temp.append("{:>3}".format(array[index]))
+
+    str_line += ", ".join(temp)
+    
+
+  print(str_line)

--- a/src/astrohack/_utils/_dio.py
+++ b/src/astrohack/_utils/_dio.py
@@ -550,3 +550,67 @@ def _get_attrs(zarr_obj):
     return {
         k: v for k, v in zarr_obj.attrs.asdict().items() if not k.startswith("_NC")
     }
+
+def _reshape(array, columns):
+  size = len(array)
+  rows = int(size/columns)
+  if rows <= 0:
+    return 1, 0
+  else:  
+    remainder = size - (rows*columns)
+
+    return rows, remainder
+
+def _print_array(array, columns, indent=4):
+
+  rows, remainder = _reshape(array, columns)
+  
+  if columns > len(array):
+    columns = len(array)
+
+  str_line = ""
+
+  for i in range(rows):
+    temp = []
+    for j in range(columns):
+      k = columns*i + j
+      if j == 0:
+        temp.append("{:>3}".format(array[k]).rjust(indent, ' '))
+      else:
+        temp.append("{:>3}".format(array[k]))
+  
+    str_line += ", ".join(temp)
+    str_line += "\n"
+
+  temp = []
+  if remainder > 0:
+    for i in range(remainder):
+      index = columns*rows + i
+
+      if i == 0:
+        temp.append("{:>3}".format(array[index]).rjust(indent, ' '))
+      else:
+        temp.append("{:>3}".format(array[index]))
+
+    str_line += ", ".join(temp)
+    
+
+  print(str_line)
+
+def _print_json(object, indent=6, columns=7):
+  if isinstance(object, list):
+    if indent > 3:
+      list_indent = indent-3
+    else:
+      list_indent = 0
+
+    print("{open}".format(open="[").rjust(list_indent, ' '))
+    _print_array(object, columns=columns, indent=indent+1)
+    print("{close}".format(close="]").rjust(list_indent, ' '))
+
+  else:
+    for key, value in object.items():
+      key_str="{key}{open}".format(key=key, open=":{")
+      print("{key}".format(key=key_str).rjust(indent, ' '))
+      _print_json(value, indent+4, columns=columns)
+      print("{close}".format(close="}").rjust(indent-4, ' '))

--- a/src/astrohack/_utils/_dio.py
+++ b/src/astrohack/_utils/_dio.py
@@ -561,42 +561,6 @@ def _reshape(array, columns):
 
     return rows, remainder
 
-def _print_array(array, columns, indent=4):
-
-  rows, remainder = _reshape(array, columns)
-  
-  if columns > len(array):
-    columns = len(array)
-
-  str_line = ""
-
-  for i in range(rows):
-    temp = []
-    for j in range(columns):
-      k = columns*i + j
-      if j == 0:
-        temp.append("{:>3}".format(array[k]).rjust(indent, ' '))
-      else:
-        temp.append("{:>3}".format(array[k]))
-  
-    str_line += ", ".join(temp)
-    str_line += "\n"
-
-  temp = []
-  if remainder > 0:
-    for i in range(remainder):
-      index = columns*rows + i
-
-      if i == 0:
-        temp.append("{:>3}".format(array[index]).rjust(indent, ' '))
-      else:
-        temp.append("{:>3}".format(array[index]))
-
-    str_line += ", ".join(temp)
-    
-
-  print(str_line)
-
 def _print_json(object, indent=6, columns=7):
   if isinstance(object, list):
     if indent > 3:

--- a/src/astrohack/_utils/_dio.py
+++ b/src/astrohack/_utils/_dio.py
@@ -551,16 +551,6 @@ def _get_attrs(zarr_obj):
         k: v for k, v in zarr_obj.attrs.asdict().items() if not k.startswith("_NC")
     }
 
-def _reshape(array, columns):
-  size = len(array)
-  rows = int(size/columns)
-  if rows <= 0:
-    return 1, 0
-  else:  
-    remainder = size - (rows*columns)
-
-    return rows, remainder
-
 def _print_json(object, indent=6, columns=7):
   if isinstance(object, list):
     if indent > 3:

--- a/src/astrohack/dio.py
+++ b/src/astrohack/dio.py
@@ -234,7 +234,7 @@ def print_json(object, indent=6, columns=7):
             print_json(value, indent+4, columns=columns)
             print("{close}".format(close="}").rjust(indent-4, ' '))
 
-def print_holog_obs_dict(file='.holog_obs_dict.json', style='static', indent=6, columns=7):
+def inspect_holog_obs_dict(file='.holog_obs_dict.json', style='static', indent=6, columns=7):
     """ Print formatted holography observation dictionary
 
     :param file: Input file, can be either JSON file or string., defaults to '.holog_obs_dict.json'

--- a/src/astrohack/extract_holog.py
+++ b/src/astrohack/extract_holog.py
@@ -463,3 +463,219 @@ def _check_extract_holog_parms(fname,
     _parm_check_passed(fname, parms_passed)
 
     return extract_holog_parms
+
+def generate_holog_obs_dict(
+    ms_name,
+    holog_obs_dict=None,
+    ddi=None,
+    baseline_average_distance=None,
+    baseline_average_nearest=None,
+    holog_name=None,
+    point_name=None,
+    data_column="CORRECTED_DATA",
+    parallel=False,
+    reuse_point_zarr=False,
+    overwrite=False,
+):
+    """
+    Extract holography and optionally pointing data, from measurement set. Creates holography output file.
+
+    :param ms_name: Name of input measurement file name.
+    :type ms_name: str
+    :param holog_obs_dict: The *holog_obs_dict* describes which scan and antenna data to extract from the measurement set. As detailed below, this compound dictionary also includes important meta data needed for preprocessing and extraction of the holography data from the measurement set. If not specified holog_obs_dict will be generated. For auto generation of the holog_obs_dict the assumtion is made that the same antanna beam is not mapped twice in a row (alternating sets of antennas is fine).
+    :type holog_obs_dict: dict, optional
+    :param ddi:  DDI(s) that should be extracted from the measurement set. Defaults to all DDI's in the ms.
+    :type ddi: int numpy.ndarray | int list, optional
+    :param baseline_average_distance: To increase the signal to noise for a mapping antenna mutiple reference antennas can be used. The baseline_average_distance is the acceptable distance between a mapping antenna and a reference antenna. The baseline_average_distance is only used if the holog_obs_dict is not specified. If no distance is specified all reference antennas will be used. baseline_average_distance and baseline_average_nearest can not be used together.
+    :type holog_obs_dict: float, optional
+    :param baseline_average_nearest: To increase the signal to noise for a mapping antenna mutiple reference antennas can be used. The baseline_average_nearest is the number of nearest reference antennas to use. The baseline_average_nearest is only used if the holog_obs_dict is not specified.  baseline_average_distance and baseline_average_nearest can not be used together.
+    :type holog_obs_dict: int, optional
+    :param holog_name: Name of *<holog_name>.holog.zarr* file to create. Defaults to measurement set name with *holog.zarr* extension.
+    :type holog_name: str, optional
+    :param point_name: Name of *<point_name>.point.zarr* file to create. Defaults to measurement set name with *point.zarr* extension.
+    :type point_name: str, optional
+    :param data_column: Determines the data column to pull from the measurement set. Defaults to "CORRECTED_DATA".
+    :type data_column: str, optional, ex. DATA, CORRECTED_DATA
+    :param parallel: Boolean for whether to process in parallel. Defaults to False
+    :type parallel: bool, optional
+    :param reuse_point_zarr: If true the point.zarr specified in point_name is reused.
+    :type reuse_point_zarr: bool, optional
+    :param overwrite: Boolean for whether to overwrite current holog.zarr and point.zarr files., defaults to False
+    :type overwrite: bool, optional
+
+    :return: Holography holog object.
+    :rtype: AstrohackHologFile
+
+    .. _Description:
+
+    **AstrohackHologFile**
+
+    Holog object allows the user to access holog data via compound dictionary keys with values, in order of depth, `ddi` -> `map` -> `ant`. The holog object also provides a `summary()` helper function to list available keys for each file. An outline of the holog object structure is show below:
+
+    .. parsed-literal::
+        holog_mds = 
+        {
+            ddi_0:{
+                map_0:{
+                 ant_0: holog_ds,
+                          ⋮
+                 ant_n: holog_ds
+                },
+                ⋮
+                map_p: …
+            },
+            ⋮
+            ddi_m: …
+        }
+
+    **Additional Information**
+
+        This function extracts the holography related information from the given measurement file. The data is restructured into an astrohack file format and saved into a file in the form of *<holog_name>.holog.zarr*. The extension *.holog.zarr* is used for all holography files. In addition, the pointing information is recorded into a holography file of format *<pointing_name>.point.zarr*. The extension *.point.zarr* is used for all holography pointing files. 
+
+        **holog_obs_dict[holog_mapping_id] (dict):**
+        *holog_mapping_id* is a unique, arbitrary, user-defined integer assigned to the data that describes a single complete mapping of the beam.
+        
+        .. rubric:: This is needed for two reasons:
+        * A complete mapping of the beam can be done over more than one scan (for example the VLA data). 
+        * A measurement set can contain more than one mapping of the beam (for example the ALMA data).
+    
+        **holog_obs_dict[holog_mapping_id][scans] (int | numpy.ndarray | list):**
+        All the scans in the measurement set the *holog_mapping_id*.
+    
+        **holog_obs_dict[holog_mapping_id][ant] (dict):**
+        The dictionary keys are the mapping antenna names and the values a list of the reference antennas. See example below.
+
+        The below example shows how the *holog_obs_description* dictionary should be laid out. For each *holog_mapping_id* the relevant scans 
+        and antennas must be provided. For the `ant` key, an entry is required for each mapping antenna and the accompanying reference antenna(s).
+    
+        .. parsed-literal::
+            holog_obs_description = {
+                'map_0' :{
+                    'scans':[2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22],
+                    'ant':{
+                        'DA44':[
+                            'DV02', 'DV03', 'DV04', 
+                            'DV11', 'DV12', 'DV13', 
+                            'DV14', 'DV15', 'DV16', 
+                            'DV17', 'DV18', 'DV19', 
+                            'DV20', 'DV21', 'DV22', 
+                            'DV23', 'DV24', 'DV25'
+                        ]
+                    }
+                }
+            }
+
+    """
+    logger = _get_astrohack_logger()
+    
+    fname = 'extract_holog'
+    ######### Parameter Checking #########
+    extract_holog_parms = _check_extract_holog_parms(fname,
+                                                     ms_name,
+                                                     holog_obs_dict,
+                                                     ddi,
+                                                     baseline_average_distance,
+                                                     baseline_average_nearest,
+                                                     holog_name,
+                                                     point_name,
+                                                     data_column,
+                                                     parallel,
+                                                     reuse_point_zarr,
+                                                     overwrite)
+    input_params = extract_holog_parms.copy()
+    
+    check_if_file_exists(fname, extract_holog_parms['ms_name'])
+    check_if_file_will_be_overwritten(fname, extract_holog_parms['holog_name'], extract_holog_parms['overwrite'])
+    check_if_file_will_be_overwritten(fname, extract_holog_parms['point_name'], extract_holog_parms['overwrite'])
+        
+    ############# Exstract pointing infromation and save to point.zarr #############
+    if extract_holog_parms["reuse_point_zarr"]:
+        try:
+            pnt_dict = _load_point_file(extract_holog_parms['point_name'])
+        except:
+            logger.warning(f'[{fname}]: Could not find {extract_holog_parms["point_name"]}, creating point new '
+                           f'point.zarr.')
+            pnt_dict = _extract_pointing(extract_holog_parms['ms_name'], extract_holog_parms['point_name'],
+                                         parallel=extract_holog_parms['parallel'])
+    else:
+        pnt_dict = _extract_pointing(extract_holog_parms['ms_name'], extract_holog_parms['point_name'],
+                                     parallel=extract_holog_parms['parallel'])
+
+    ######## Get Spectral Windows ########
+    ctb = ctables.table(
+        os.path.join(extract_holog_parms['ms_name'], "DATA_DESCRIPTION"),
+        readonly=True,
+        lockoptions={"option": "usernoread"},
+        ack=False,
+    )
+    ddi_spw = ctb.getcol("SPECTRAL_WINDOW_ID")
+    ddpol_indexol = ctb.getcol("POLARIZATION_ID")
+    ms_ddi = np.arange(len(ddi_spw))
+    ctb.close()
+
+    ######## Get Antenna IDs and Names ########
+    ctb = ctables.table(
+        os.path.join(extract_holog_parms['ms_name'], "ANTENNA"),
+        readonly=True,
+        lockoptions={"option": "usernoread"},
+        ack=False,
+    )
+
+    ant_names = np.array(ctb.getcol("NAME"))
+    ant_id = np.arange(len(ant_names))
+    ant_pos = ctb.getcol("POSITION")
+
+    ctb.close()
+    
+    ######## Get Antenna IDs that are in the main table########
+    ctb = ctables.table(
+        extract_holog_parms['ms_name'],
+        readonly=True,
+        lockoptions={"option": "usernoread"},
+        ack=False,
+    )
+
+    ant1 = np.unique(ctb.getcol("ANTENNA1"))
+    ant2 = np.unique(ctb.getcol("ANTENNA2"))
+    ant_id_main = np.unique(np.append(ant1,ant2))
+    
+    ant_names_main = ant_names[ant_id_main]
+    ctb.close()
+    
+    # Create holog_obs_dict or modify user supplied holog_obs_dict.
+    ddi = extract_holog_parms['ddi_sel']
+    if holog_obs_dict is None: #Automatically create holog_obs_dict
+        from astrohack._utils._extract_holog import _create_holog_obs_dict
+        holog_obs_dict = _create_holog_obs_dict(pnt_dict, extract_holog_parms['baseline_average_distance'],
+                                                extract_holog_parms['baseline_average_nearest'], ant_names, ant_pos,
+                                                ant_names_main)
+        
+        #From the generated holog_obs_dict subselect user supplied ddis.
+        if ddi != 'all':
+            holog_obs_dict_keys = list(holog_obs_dict.keys())
+            for ddi_key in holog_obs_dict_keys:
+                if 'ddi' in ddi_key:
+                    ddi_id = int(ddi_key.replace('ddi_',''))
+                    if ddi_id not in ddi:
+                        del holog_obs_dict[ddi_key]
+    else:
+        #If a user defines a holog_obs_dict it needs to be duplicated for each ddi.
+        holog_obs_dict_with_ddi = {}
+        if ddi == 'all':
+            for ddi_id in ms_ddi:
+                holog_obs_dict_with_ddi['ddi_' + str(ddi_id)] = holog_obs_dict
+        else:
+            for ddi_id in ddi:
+                holog_obs_dict_with_ddi['ddi_' + str(ddi_id)] = holog_obs_dict
+        
+        holog_obs_dict = holog_obs_dict_with_ddi
+
+
+    outfile_obj = copy.deepcopy(holog_obs_dict)
+
+    _jsonify(outfile_obj)
+
+    with open(".holog_obs_dict.json", "w") as outfile:
+        json.dump(outfile_obj, outfile)
+
+    return outfile_obj


### PR DESCRIPTION
This ticket adds not **one** but **two**, count them, **two** awesome user facing functions.

- `generate_holog_obs_dict(...)`: this is a user requested function that allows for the generation of the full holography observation dictionary for a measurement file. The interface and even most of the code is the same as what is used in `extract_holog()` minus a few details. Also the function returns the holog dictionary as a json object.
- `inspect_holog_obs_dict()`: This is a nicely formatted inspection dictionary based on a json printing library. It can take both the holog_obs_dict json object or path to the object on disk as an input and will display the object in one of two modes.

1. _static mode_ - Static mode is a formatted string output and allows the user to define how the antenna dictionary list is handled. By adjusting the columns input variable the user can for instance take an scan list of length of 15 and display it as 3 rows of 5 columns (this would be `columns=5`). The reshaping code will look at the list and reshape it even if the length is not an exact split, ie. length =17 with columns=5 would give 4 rows as output with the last row being the remainders.
![inspect_holog_obs_1](https://github.com/casangi/astrohack/assets/2530451/085b6edd-9fe3-4ad6-8910-66b99b767156)
![inspect_holog_obs_dict_2](https://github.com/casangi/astrohack/assets/2530451/a9ded039-1ecb-4ca2-ba49-fdeec7a62dc8)
2. _dynamic mode_ -  Dynamic mode returns a collapsible json dictionary in the cell so that the user can look at only certain parts of large holog dictionaries. For example:
![holog_obs_dict_dynamic](https://github.com/casangi/astrohack/assets/2530451/56f1fc87-9fd8-4833-acb8-73c0281f9f2d)

If this all looks good I will add them to the visualization notebook to show Pedro next week.
