### PR TITLE
104 define the ci pipeline for pushes to branches

### DIFF
--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,13 +31,13 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v --html=pytest-report.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules --junitxml=junit/pytest-results-${{ matrix.python-version }}.xml
-    - name: Upload pytest results
-      uses: actions/upload-artifact@v3
-      with:
-        name: pytest-results-${{ matrix.python-version }}
-        path: |
-          junit/pytest-results-${{ matrix.python-version }}.xml
-          ./pytest-report.html
+        pytest -v
+#    - name: Upload pytest results
+#      uses: actions/upload-artifact@v3
+#      with:
+#        name: pytest-results-${{ matrix.python-version }}
+#        path: |
+#          junit/pytest-results-${{ matrix.python-version }}.xml
+#          ./pytest-report.html
       # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
+#      if: ${{ always() }}

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v tests/test* --html=pytest-results-${{ matrix.python-version }}.html -cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
+        pytest -v tests/test* --html=pytest-results-${{ matrix.python-version }}.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
     - name: Upload pytest results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8"]
+        python-version: ["3.8","3.9","3.10","3.11"]
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v tests/test* --html=pytest-results-${{ matrix.python-version }}.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
+        pytest -v tests/ --html=pytest-results-${{ matrix.python-version }}.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
     - name: Upload pytest results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,13 +31,12 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v --html=pytest-report.html
-#    - name: Upload pytest results
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: pytest-results-${{ matrix.python-version }}
-#        path: |
-#          junit/pytest-results-${{ matrix.python-version }}.xml
-#          ./pytest-report.html
+        pytest -v --html=pytest-results-${{ matrix.python-version }}.html
+    - name: Upload pytest results
+      uses: actions/upload-artifact@v3
+      with:
+        name: pytest-results-${{ matrix.python-version }}
+        path: |
+          pytest-results-${{ matrix.python-version }}.html
       # Use always() to always run this step to publish test results when there are test failures
-#      if: ${{ always() }}
+      if: ${{ always() }}

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,12 +31,14 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v tests/ --html=pytest-results-${{ matrix.python-version }}.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules --junitxml=test-results-${{ matrix.python-version }}.xml
-    - name: Upload pytest results
+        pytest -v tests/ --html=test-results.html --self-contained-html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
+
+    - name: Upload pytest test results and coverage reports
       uses: actions/upload-artifact@v3
       with:
         name: pytest-results-${{ matrix.python-version }}
         path: |
-          pytest-results-${{ matrix.python-version }}.html
+          ./test-results.html
+          ./htmlcov
       # Use always() to always run this step to publish test results when there are test failures
       if: ${{ always() }}

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10","3.11"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v3
 
@@ -31,4 +31,13 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest
+        pytest -v --html=pytest-report.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules --junitxml=junit/pytest-results-${{ matrix.python-version }}.xml
+    - name: Upload pytest results
+      uses: actions/upload-artifact@v3
+      with:
+        name: pytest-results-${{ matrix.python-version }}
+        path: |
+          junit/pytest-results-${{ matrix.python-version }}.xml
+          ./pytest-report.html
+      # Use always() to always run this step to publish test results when there are test failures
+      if: ${{ always() }}

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v tests/ --html=pytest-results-${{ matrix.python-version }}.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
+        pytest -v tests/ --html=pytest-results-${{ matrix.python-version }}.html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules --junitxml=test-results-${{ matrix.python-version }}.xml
     - name: Upload pytest results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v --html=pytest-results-${{ matrix.python-version }}.html -cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
+        pytest -v tests/test* --html=pytest-results-${{ matrix.python-version }}.html -cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
     - name: Upload pytest results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v --html=pytest-results-${{ matrix.python-version }}.html
+        pytest -v --html=pytest-results-${{ matrix.python-version }}.html -cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
     - name: Upload pytest results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -31,7 +31,7 @@ jobs:
         pip install .
     - name: Test with pytest
       run: |
-        pytest -v
+        pytest -v --html=pytest-report.html
 #    - name: Upload pytest results
 #      uses: actions/upload-artifact@v3
 #      with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
 'numpy',
 'prettytable',
 'pytest',
+'pytest-cov',
+'pytest-html',
 'scikit_image',
 'scipy',
 'xarray',

--- a/tests/unit/test_astrohack_import_template.py
+++ b/tests/unit/test_astrohack_import_template.py
@@ -13,11 +13,11 @@ class TestAstrohack():
         such as deleting test data """
         pass
 
-    def setup(self):
+    def setup_method(self):
         """ setup any state specific to all methods of the given class """
         pass
 
-    def teardown(self):
+    def teardown_method(self):
         """ teardown any state that was previously setup for all methods of the given class """
         pass
 


### PR DESCRIPTION
@jrhosk , I have added support to create html reports from pytest and it also creates coverage reports.
The results of tests and coverage are uploaded to the Artifacts of the actions. In this case it will create
one zip file for each version of python with the html results. For now I have not found a way to see the html
directly in the browser. One needs to download the zip file, unzip and load the html in the browser.
I have merged main to my branch, therefore it should be up-to-date and if you can, this one is ready to
merge after your review. There were many commits due to my trial-and-error development.