### PR TITLE
Fixed astrohack specific worker call in astrohack worker.

### DIFF
--- a/src/astrohack/_utils/_dask_plugins/_astrohack_worker.py
+++ b/src/astrohack/_utils/_dask_plugins/_astrohack_worker.py
@@ -1,7 +1,8 @@
 import click
+import skriba.logger
 
 
-class AstrohackWorker():
+class AstrohackWorker:
     def __init__(self, local_cache, log_params):
         self.logger = None
         self.worker = None
@@ -22,7 +23,7 @@ class AstrohackWorker():
         registered.
         """
 
-        self.logger = skriba.logger.setup_logger(
+        self.logger = skriba.logger.setup_worker_logger(
             logger_name="astrohack",
             log_to_term=self.log_to_term,
             log_to_file=self.log_to_file,
@@ -54,4 +55,4 @@ async def dask_setup(worker, local_cache, log_to_term, log_to_file, log_file, lo
     log_params = {'log_to_term': log_to_term, 'log_to_file': log_to_file, 'log_file': log_file, 'log_level': log_level}
     plugin = AstrohackWorker(local_cache, log_params)
 
-    await worker.client.register_worker_plugin(plugin, name='astrohack_worker')
+    await worker.client.register_worker_plugin(plugin, name='worker_logger')

--- a/src/astrohack/_utils/_logger/_astrohack_logger.py
+++ b/src/astrohack/_utils/_logger/_astrohack_logger.py
@@ -14,13 +14,13 @@
 
 
 hack_logger_name = 'astrohack'
-import sys
 import logging
+import sys
 from datetime import datetime
+
+
 # formatter = logging.Formatter("[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s")
 # formatter = logging.Formatter("[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s")
-from dask.distributed import WorkerPlugin
-import dask
 
 
 class astrohack_formatter(logging.Formatter):
@@ -34,8 +34,6 @@ class astrohack_formatter(logging.Formatter):
     start_msg = "%(asctime)s - "
     middle_msg = "%(levelname)-8s"
     end_msg = " - %(name)s - (%(filename)s:%(lineno)d) - %(message)s"
-
-    import inspect
 
     FORMATS = {
         logging.DEBUG: start_msg + DEBUG + middle_msg + reset + end_msg,
@@ -128,7 +126,6 @@ class _astrohack_worker_logger_plugin(WorkerPlugin):
 
 
 def _setup_astrohack_worker_logger(log_to_term, log_to_file, log_file, log_level, worker_id):
-    from dask.distributed import get_worker
     # parallel_logger_name = _get_astrohack_worker_logger_name()
     parallel_logger_name = hack_logger_name + '_' + str(worker_id)
 

--- a/src/astrohack/_utils/_panel_classes/antenna_surface.py
+++ b/src/astrohack/_utils/_panel_classes/antenna_surface.py
@@ -1,5 +1,8 @@
+import numpy as np
 import xarray as xr
+
 from matplotlib import patches
+
 import skriba.logger
 
 from astrohack._utils._panel_classes.base_panel import PANEL_MODELS, irigid

--- a/src/astrohack/client.py
+++ b/src/astrohack/client.py
@@ -174,7 +174,7 @@ def local_client(
 
     if local_cache or _worker_log_params:
         plugin = AstrohackWorker(local_cache, _worker_log_params)
-        client.register_worker_plugin(plugin, name='astrohack_worker')
+        client.register_worker_plugin(plugin, name='worker_logger')
 
     logger.info('Created client ' + str(client))
 


### PR DESCRIPTION
The problem is in how and where the astrohack specific worker plugin is called. The logger currently has a specific place in the skriba repo where I converted this plugin but the plugin from astrohack is still called so the naming was all wrong. I have patched it for the time being and will make a more robust plugin register mechanism in the new year with the full independent logger.

the notebook shows everything working as expected on my side now.