### PR TITLE
Update github workflows to use v4 of artifact actions

### DIFF
--- a/.github/workflows/python-testing-linux.yml
+++ b/.github/workflows/python-testing-linux.yml
@@ -37,7 +37,7 @@ jobs:
         pytest -v tests/ --html=test-results.html --self-contained-html --cov=astrohack --no-cov-on-fail --cov-report=html --doctest-modules
 
     - name: Upload pytest test results and coverage reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-results-${{ matrix.python-version }}
         path: |

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build a source distribution
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/